### PR TITLE
Allow users to customize their SendgridEmailRecord

### DIFF
--- a/app/models/sendgrid_events/sendgrid_email_record.rb
+++ b/app/models/sendgrid_events/sendgrid_email_record.rb
@@ -10,5 +10,12 @@ module SendgridEvents
       %w[bounced bounced],
       %w[delivered delivered]
     ]
+
+    def self.create_from_headers!(headers, additional_attributes)
+      create!(:to      => headers[:to],
+              :from    => headers[:from],
+              :subject => headers[:subject],
+              :status  => 'processing')
+    end
   end
 end

--- a/lib/sendgrid_events/action_mailer_override.rb
+++ b/lib/sendgrid_events/action_mailer_override.rb
@@ -8,6 +8,7 @@ module SendgridEvents
 
     attr_accessor :sendgrid_email_record_attributes
     def sendgrid_email_record_attributes(attrs = nil)
+      @sendgrid_email_record_attributes ||= {}
       return @sendgrid_email_record_attributes if attrs.nil?
       self.sendgrid_email_record_attributes = attrs
     end

--- a/lib/sendgrid_events/action_mailer_override.rb
+++ b/lib/sendgrid_events/action_mailer_override.rb
@@ -6,16 +6,19 @@ module SendgridEvents
       alias_method_chain :mail, :record_email
     end
 
+    attr_accessor :sendgrid_email_record_attributes
+    def sendgrid_email_record_attributes(attrs = nil)
+      return @sendgrid_email_record_attributes if attrs.nil?
+      self.sendgrid_email_record_attributes = attrs
+    end
+
     def uniq_args_with_merge_args(args)
       set_args = send_grid_header.data[:unique_args] ||= {}
       uniq_args_without_merge_args set_args.merge(args)
     end
 
     def mail_with_record_email(headers={}, &block)
-      id = SendgridEmailRecord.create!(:to => headers[:to],
-                                       :from => headers[:from],
-                                       :subject => headers[:subject],
-                                       :status => 'processing').id
+      id = SendgridEmailRecord.create_from_headers!(headers, sendgrid_email_record_attributes).id
       uniq_args :sendgrid_events_id => id
       mail_without_record_email headers, &block
     end

--- a/spec/sendgrid_events/action_mailer_override_spec.rb
+++ b/spec/sendgrid_events/action_mailer_override_spec.rb
@@ -2,26 +2,41 @@ require 'spec_helper'
 
 class TestMailer < ActionMailer::Base
   def test_mail
+    sendgrid_email_record_attributes user_id: 42
     mail(to: "to@example.com", from: "from@example.com", subject: "Test Mail")
   end
 end
 
 module SendgridEvents
   describe ActionMailerOverride do
-    before { @mail = TestMailer.test_mail }
     let(:recorded_email) { SendgridEvents::SendgridEmailRecord.last }
 
 
     describe "records the sent email" do
+      before { @mail = TestMailer.test_mail }
       specify { recorded_email.to.should      == "to@example.com"   }
       specify { recorded_email.from.should    == "from@example.com" }
       specify { recorded_email.subject.should == "Test Mail"        }
       specify { recorded_email.status.should  == 'processing'       }
     end
 
-    it "stores new event record's id in the uniq args" do
-      sendgrid_header = @mail.instance_variable_get(:@sendgrid_header)
-      sendgrid_header.data[:unique_args].should == {sendgrid_events_id: recorded_email.id}
+    describe "stores new event record's id in the uniq args" do
+      before                { @mail = TestMailer.test_mail }
+      let(:sendgrid_header) { @mail.instance_variable_get(:@sendgrid_header) }
+
+      specify { sendgrid_header.data[:unique_args].should == { sendgrid_events_id: recorded_email.id} }
+    end
+
+    describe "passes additional attributes to SendgridEmailRecord" do
+      let(:email_record) { stub.as_null_object }
+
+      specify do
+        SendgridEmailRecord.should_receive(:create_from_headers!).with do |_, additional_attributes|
+          additional_attributes.should == { user_id: 42 }
+        end.and_return(email_record)
+
+        TestMailer.test_mail
+      end
     end
   end
 end


### PR DESCRIPTION
Users can redefine SendgridEmailRecord.create_from_headers! method.
They also have new method in mailer - `sendgrid_email_record_attribute`.

```
def send_something
  sendgrid_email_record_attribute user_id: 12
end
```

Then `SendgridEmailRecord.create_from_headers!` will be called with
mail headers and this additional attributes.

```
class SendgridEmailRecord < ActiveRecord::Base
  # redefined method in user's app
  def self.create_from_headers!(headers, additional_attributes)
      create!(:to      => headers[:to],
              :from    => headers[:from],
              :subject => headers[:subject],
              :user_id => additional_attributes[:user_id]
              :status  => 'processing')
  end
end
```
