### PR TITLE
Correct statuses for SendgridEmailRecord

### DIFF
--- a/app/models/sendgrid_events/sendgrid_email_record.rb
+++ b/app/models/sendgrid_events/sendgrid_email_record.rb
@@ -4,11 +4,16 @@ module SendgridEvents
     # Message
     include EnumeratedField
     enum_field :status, [
-      %w[processing processing],
-      %w[dropped dropped],
-      %w[deferred deferred],
       %w[bounced bounced],
-      %w[delivered delivered]
+      %w[clicked clicked],
+      %w[deferred deferred],
+      %w[delivered delivered],
+      %w[dropped dropped],
+      %w[opened opened],
+      %w[processed processed],
+      %w[processing processing],
+      %w[spamreported spamreported],
+      %w[unsubscribed unsubscribed],
     ]
   end
 end

--- a/lib/sendgrid_events/handlers/base.rb
+++ b/lib/sendgrid_events/handlers/base.rb
@@ -24,7 +24,7 @@ module SendgridEvents
           handlee = handlee.to_s
           registered_handlers[handlee] = self.name.constantize
           self.name.constantize.send :define_singleton_method, :handlee do
-            handlee
+            self.name.demodulize.downcase
           end
         else
           raise ArgumentError, "#{handlee.to_s.titleize} is not in the Dispatch's list of acceptable handlers"

--- a/spec/sendgrid_events/handlers/bounced_spec.rb
+++ b/spec/sendgrid_events/handlers/bounced_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Bounced do
       subject { Bounced }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'bounced' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/clicked_spec.rb
+++ b/spec/sendgrid_events/handlers/clicked_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Clicked do
       subject { Clicked }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'clicked' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/deferred_spec.rb
+++ b/spec/sendgrid_events/handlers/deferred_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Deferred do
       subject { Deferred }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'deferred' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/delivered_spec.rb
+++ b/spec/sendgrid_events/handlers/delivered_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Delivered do
       subject { Delivered }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'delivered' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/dropped_spec.rb
+++ b/spec/sendgrid_events/handlers/dropped_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Dropped do
       subject { Dropped }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'dropped' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/opened_spec.rb
+++ b/spec/sendgrid_events/handlers/opened_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Opened do
       subject { Opened }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'opened' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/processed_spec.rb
+++ b/spec/sendgrid_events/handlers/processed_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Processed do
       subject { Processed }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'processed' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/spam_reported_spec.rb
+++ b/spec/sendgrid_events/handlers/spam_reported_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe SpamReported do
       subject { SpamReported }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'spamreported' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,

--- a/spec/sendgrid_events/handlers/unsubscribed_spec.rb
+++ b/spec/sendgrid_events/handlers/unsubscribed_spec.rb
@@ -4,7 +4,7 @@ module SendgridEvents
     describe Unsubscribed do
       subject { Unsubscribed }
       it { should respond_to(:handle) }
-      it { should respond_to(:handlee) }
+      its(:handlee) { should == 'unsubscribed' }
       let(:event) { {
         :email => "foo@bar.com",
         :timestamp => 1322000095,


### PR DESCRIPTION
- update list of valid statuses for SendgridEmailRecord
- use correct status value from handlers like Bounce - should be `bounced`, not `bounce`
